### PR TITLE
Fix loading with Quark/DynamicTrees

### DIFF
--- a/Legacy Sodium/src/main/java/me/jellysquid/mods/sodium/common/config/SodiumConfig.java
+++ b/Legacy Sodium/src/main/java/me/jellysquid/mods/sodium/common/config/SodiumConfig.java
@@ -102,17 +102,17 @@ public class SodiumConfig {
 
         if(FMLLoader.getLoadingModList().getModFileById("quark") != null)
         {
-            this.options.get("features.item").addModOverride(false, "quark");
+            this.options.get("mixin.features.item").addModOverride(false, "quark");
         }
 
         if(FMLLoader.getLoadingModList().getModFileById("abnormals_core") != null)
         {
-            this.options.get("features.world_ticking").addModOverride(false, "quark");
+            this.options.get("mixin.features.world_ticking").addModOverride(false, "quark");
         }
 
         if(FMLLoader.getLoadingModList().getModFileById("dynamictrees") != null)
         {
-            this.options.get("features.world_ticking").addModOverride(false, "dynamictrees");
+            this.options.get("mixin.features.world_ticking").addModOverride(false, "dynamictrees");
         }
 
     }


### PR DESCRIPTION
addMixinRule is applying a rule name prefix when adding to options but it isn't being used when indexing. Can confirm this fixes the failed load and renders DynamicTrees.

However there are still some non-critical issues with rendering them. Branches do not connect to neighboring blocks. Oddly enough, it works fine when the tree is chopped down and starts animating, presumably as one big model.

![2021-10-06_00 52 13](https://user-images.githubusercontent.com/67132971/136142691-924e56a8-a810-42ba-9a21-428e19b550c4.png)